### PR TITLE
added code that corresponds to media queries video

### DIFF
--- a/web-development/frontend/foundation/07-responsive-landing-page/media-queries-demo/index.html
+++ b/web-development/frontend/foundation/07-responsive-landing-page/media-queries-demo/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Media Query Demo</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" type="text/css" href="media_queries.css">
+    </head>
+    <body>
+        <div>
+            <h2></h2>
+        </div>
+    </body>
+</html>

--- a/web-development/frontend/foundation/07-responsive-landing-page/media-queries-demo/media_queries.css
+++ b/web-development/frontend/foundation/07-responsive-landing-page/media-queries-demo/media_queries.css
@@ -1,0 +1,33 @@
+/*
+ * ~Logical Operators~
+ *
+ * `only`, `not`, `and`, `or`, or a comma
+ */
+
+h2 {
+    width: 100%;
+    font-size: 24px;
+    color: black;
+}
+
+@media only screen
+    and (min-width: 320px) {
+    h2:after {
+        content: "Our device is at least 320px wide right now.";   
+    }
+}
+
+@media only screen
+    and (min-width: 768px) {
+    h2:after {
+        content: "This screen must be an iPad";   
+    }
+}
+
+@media only screen
+    and (min-width: 320px)
+    and (orientation: landscape) {
+    h2:after {
+        content: "We must be in landscape mode now.";   
+    }
+}


### PR DESCRIPTION
@clln for videos where I'm illustrating something independent of the core code, I thought it might be useful to add the source to `curriculum_public`. Thoughts on the idea + where we might link to the source? Maybe directly below the embed?